### PR TITLE
[Fix] 중복 게시글 로드 현상 수정, 빠르게 스크롤을 내릴 시 중복요청 해결

### DIFF
--- a/client/src/components/Post/Posts/index.jsx
+++ b/client/src/components/Post/Posts/index.jsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import PostCard from '../PostCard';
 import { useEffect } from 'react';
 import { loadPosts } from 'redux/actions/post';
+import _throttle from 'lodash/throttle';
 const CardList = styled.div`
   border: 1px solid #d9d9d9;
   padding: 10px;
@@ -13,25 +14,32 @@ function Posts() {
   const { posts, loadPostsLoading, hasMorePosts } = useSelector((state) => state.post);
   const dispatch = useDispatch();
 
+  const scrollY = _throttle(() => {
+    console.log(window.scrollY, document.documentElement.clientHeight, document.documentElement.scrollHeight);
+    if (window.scrollY + document.documentElement.clientHeight > document.documentElement.scrollHeight - 300) {
+      if (!loadPostsLoading && hasMorePosts) {
+        console.log('이벤트', loadPostsLoading, hasMorePosts);
+        dispatch(loadPosts(posts[posts.length - 1]?._id));
+      }
+    }
+  }, 500);
+
   useEffect(() => {
     if (posts.length === 0) {
       dispatch(loadPosts());
     }
   }, []);
+
   useEffect(() => {
-    const scrollY = () => {
-      console.log(window.scrollY, document.documentElement.clientHeight, document.documentElement.scrollHeight);
-      if (window.scrollY + document.documentElement.clientHeight > document.documentElement.scrollHeight - 300) {
-        if (!loadPostsLoading && hasMorePosts) {
-          dispatch(loadPosts());
-        }
-      }
-    };
+    console.log(posts);
+  }, [posts]);
+
+  useEffect(() => {
     window.addEventListener('scroll', scrollY);
     return () => {
       window.removeEventListener('scroll', scrollY);
     };
-  }, [loadPosts, hasMorePosts, posts]);
+  }, [loadPostsLoading, hasMorePosts, posts]);
   return (
     <>
       <CardList>

--- a/client/src/redux/actions/post.js
+++ b/client/src/redux/actions/post.js
@@ -2,9 +2,9 @@ import { createAsyncThunk } from '@reduxjs/toolkit';
 import { generateDummyPost } from 'utils/generateDummyPost';
 import api from 'utils/api';
 
-export const loadPosts = createAsyncThunk('POST/LOAD_POSTS', async () => {
+export const loadPosts = createAsyncThunk('POST/LOAD_POSTS', async (data) => {
   try {
-    const response = await api.get('/post/loadpost');
+    const response = await api.get(`/post/loadpost?lastId=${data}`);
     console.log('받아온 데이터', response);
     return response;
   } catch (err) {

--- a/client/src/redux/reducers/postSlice.js
+++ b/client/src/redux/reducers/postSlice.js
@@ -61,7 +61,7 @@ const postSlice = createSlice({
         state.loadPostsLoading = false;
         state.loadPostsDone = true;
         state.loadPostsError = null;
-        state.hasMorePosts = state.posts.length < 50;
+        state.hasMorePosts = action.payload.length === 5;
         state.posts = _concat(state.posts, [...action.payload]);
       })
       .addCase(loadPosts.rejected, (state, action) => {

--- a/server/routes/posts.js
+++ b/server/routes/posts.js
@@ -8,14 +8,20 @@ const passport = require('passport');
 router.get('/test', passport.authenticate('jwt', { session: false }), async (req, res, next) => {});
 router.get('/loadpost', async (req, res, next) => {
   try {
-    let posts = await Post.find()
+    console.log('last ID =', req.query.lastId);
+    const lastID = {};
+    if (req.query.lastId !== 'undefined') {
+      lastID._id = { $lt: req.query.lastId };
+    }
+    let posts = await Post.find(lastID)
       .populate('user', { user_ID: 1 })
       .populate({
         path: 'comments',
         populate: { path: 'user', select: 'user_ID' },
         options: { sort: { createdAt: -1 } },
       })
-      .sort({ createdAt: -1 });
+      .sort({ createdAt: -1 })
+      .limit(5);
 
     return res.json(posts);
   } catch (err) {


### PR DESCRIPTION


<!--
  PR 작성 가이드
1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
2. emoji, @어노테이션 등을 사용하여 효과적으로 소통할 것.
3. 명확하게 질문하고 명확하게 답변할 것.
4. 새로운 모듈 설치시 PR message에 기재할 것.
5. PR 올리기전에 branch 반드시 확인할 것. 
-->

## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->

## 👩‍💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
- 몽구스의 limit을 5개로 설정하여 5개만 로드하도록 수정하고, 로드요청을
  할 때마다 마지막 게시글 보다 적은 _id 값을 가진 게시글을 로드하도록
  수정
- 중복요청과 데이터의 마지막을 구분하기 위해서, loadPostsLoading,
  hasMorePosts 를 사용.(!loadPostsLoading && hasMorePosts)
  pending 중에서는 loadPostsLoading = true이고
  더 불러올 게시글이 있을 때는 전에 불러온 게시글이 꽉 차 있는
  상태이므로 hasMorePosts = action.payload.length === 5 = true;
  만일 더 불러올 게시글이 없는 경우에는 hasMorePosts =
  action.payload.length < 5 = false 이거나
  새로 불러온 게시글이 없으므로 로드 못함
 - 위와같이 처리하더라도, 스크롤을 redux state가 변하기 전에 내리게 되면
  중복 이벤트가 발생하기 때문에 쓰로틀링을 사용하여 처리
## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
-

